### PR TITLE
Provide a state machine trigger Lambda function

### DIFF
--- a/entrypoint/fbPushLegacy.js
+++ b/entrypoint/fbPushLegacy.js
@@ -4,6 +4,24 @@ import { Chat } from '../lib/facebook';
 import ddb from '../lib/dynamodb';
 import Raven from 'raven';
 import RavenLambdaWrapper from 'serverless-sentry-lib';
+import * as aws from 'aws-sdk';
+
+
+export const proxy = (event, context, callback) => {
+    const params = {
+        stateMachineArn: process.env.statemachine_arn,
+        input: JSON.stringify({}),
+    };
+
+    const stepfunctions = new aws.StepFunctions();
+    stepfunctions.startExecution(params, function(err, data) {
+        if (err) {
+            console.log('err while executing step function');
+        } else {
+            console.log('started execution of step function');
+        }
+    });
+};
 
 
 export const fetch = RavenLambdaWrapper.handler(Raven, function(event, context, callback) {

--- a/entrypoint/fbPushLegacy.js
+++ b/entrypoint/fbPushLegacy.js
@@ -10,7 +10,7 @@ import * as aws from 'aws-sdk';
 export const proxy = (event, context, callback) => {
     const params = {
         stateMachineArn: process.env.statemachine_arn,
-        input: JSON.stringify({}),
+        input: JSON.stringify(JSON.parse(event.body)),
     };
 
     const stepfunctions = new aws.StepFunctions();

--- a/serverless.yml
+++ b/serverless.yml
@@ -120,7 +120,7 @@ functions:
   proxy:
     handler: entrypoint/fbPushLegacy.proxy
     environment:
-      statemachine_arn: ${self:resources.Outputs.StateMachine.Value}
+      statemachine_arn: "arn:aws:states:#{AWS::Region}:#{AWS::AccountId}:stateMachine:${self:service}-${self:provider.stage}-pushLegacy"
 
 stepFunctions:
   stateMachines:
@@ -225,8 +225,3 @@ plugins:
 
 resources:
   Resources: ${file(config/env.js):resources}
-  Outputs:
-    StateMachine:
-      Description: The ARN of the provisioning state machine
-      Value:
-        Ref: PushLegacy

--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,10 @@ provider:
       Action:
         - cloudwatch:PutMetricData
       Resource: "*"
+    - Effect: Allow
+      Action:
+        - states:StartExecution
+      Resource: "*"
 
 functions:
   fbVerify:
@@ -112,6 +116,11 @@ functions:
           name: ${self:service}-${self:provider.stage}-audio
           rate: rate(3 minutes)
           enabled: true
+
+  proxy:
+    handler: entrypoint/fbPushLegacy.proxy
+    environment:
+      statemachine_arn: ${self:resources.Outputs.StateMachine.Value}
 
 stepFunctions:
   stateMachines:
@@ -216,3 +225,8 @@ plugins:
 
 resources:
   Resources: ${file(config/env.js):resources}
+  Outputs:
+    StateMachine:
+      Description: The ARN of the provisioning state machine
+      Value:
+        Ref: PushLegacy


### PR DESCRIPTION
Source is [this blog post](https://github.com/serverless/blog/blob/master/posts/2017-09-18-how-to-manage-your-aws-step-functions-with-serverless.md), although the `Output` thing in the `resources` section didn't work for me, so I decided to generate the step function ARN directly which I think is still a decent solution.