### PR TITLE
Re-enable marking pushes as sent

### DIFF
--- a/lib/pushData.js
+++ b/lib/pushData.js
@@ -80,5 +80,5 @@ export async function markSent(id, type = 'push') {
 export default {
     getLatestPush,
     assemblePush,
-    markSent: (id, type) => {},
+    markSent,
 };

--- a/lib/pushData.js
+++ b/lib/pushData.js
@@ -1,4 +1,5 @@
 import request from 'request-promise-native';
+import moment from 'moment-timezone';
 import urls from './urls';
 import * as facebook from './facebook';
 

--- a/lib/pushData.js
+++ b/lib/pushData.js
@@ -74,7 +74,29 @@ export function assemblePush(push, preview=false) {
 }
 
 export async function markSent(id, type = 'push') {
-    return;
+    const now = moment.tz('Europe/Berlin').format();
+
+    let uri;
+    const body = { delivered: true };
+    if (type === 'push') {
+        uri = urls.push(id);
+        body['delivered_date'] = now;
+    } else if (type === 'report') {
+        uri = urls.report(id);
+    }
+
+    try {
+        const response = await request.patch({
+            uri,
+            json: true,
+            body,
+            headers: { Authorization: 'Token ' + process.env.CMS_API_TOKEN },
+        });
+        console.log(`Updated ${type} ${id} to delivered`, response);
+    } catch (e) {
+        console.log(`Failed to update ${type} ${id} to delivered`, e.message);
+        throw e;
+    }
 }
 
 export default {


### PR DESCRIPTION
This has been disabled temporarily due to bad interaction with the two production deployments. 
Merge after Informant has been shut off.